### PR TITLE
Minor fixes in OSDF repo

### DIFF
--- a/bin/couchdb/generate_design_docs.js
+++ b/bin/couchdb/generate_design_docs.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 // Scan the current directory for Javascript files that contain
 // CouchDB design documents. Such files will have the following

--- a/bin/couchdb/new_couch_user.js
+++ b/bin/couchdb/new_couch_user.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 var async = require('async');
 var commander = require('commander');

--- a/bin/new_namespace
+++ b/bin/new_namespace
@@ -1,27 +1,58 @@
 #!/bin/bash
 
-# Determine the path to this script
-ABSPATH="$(cd "${0%/*}" 2>/dev/null; echo "$PWD"/"${0##*/}")"
-DIR=`dirname $ABSPATH`
+function usage {
+    echo "$0 <directory> <namespace_name>" >&2
+    echo >&2
+    echo "This script creates an OSDF namespace in a directory. The directory" >&2
+    echo "should be the working namespace directory of the OSDF server." >&2
+    echo >&2
+    echo "e.g. /usr/src/app/working/namespaces" >&2
+    echo >&2
+    echo "The namespace_name parameter must not already exist in the namespace directory." >&2
+}
 
-NS_NAME=$1
+DIR=$1
+NS_NAME=$2
 
-if [ -z $NS_NAME ]; then
-    echo "$0 <namespace_name>" >&2
-    exit 1;
+if [ -z $DIR ]; then
+    echo "A directory parameter must be specified." >&2
+    usage
+    exit 1
 fi
 
-if [ -d "$DIR/namespaces/$NS_NAME" ]; then
-    echo "It appears that this namespace already exists." >&2
+if [ -z $NS_NAME ]; then
+    echo "A namespace name parameter must be specified." >&2
+    usage
+    exit 1
+fi
+
+if [ ! "${DIR##*/}" = "namespaces" ]; then
+    echo "The directory parameter must end in \`namespaces\`." >&2
+    echo
+    usage
+    exit 1
+fi
+
+if [ ! -e $DIR ]; then
+    echo "Namespace directory <<$DIR>> must exist." >&2
+    echo
+    usage
     exit 2;
 fi
 
-mkdir "$DIR/namespaces/$NS_NAME" && \
-mkdir "$DIR/namespaces/$NS_NAME/aux" && \
-mkdir "$DIR/namespaces/$NS_NAME/schemas" && \
-mkdir "$DIR/namespaces/$NS_NAME/vocabs"
+if [ -e "$DIR/$NS_NAME" ]; then
+    echo "File with name <<$NS_NAME>> already exists within the namespace directory." >&2
+    echo
+    usage
+    exit 2;
+fi
 
-INFO_JSON="$DIR/namespaces/$NS_NAME/info.json"
+mkdir "$DIR/$NS_NAME" && \
+mkdir "$DIR/$NS_NAME/aux" && \
+mkdir "$DIR/$NS_NAME/schemas" && \
+mkdir "$DIR/$NS_NAME/acls"
+
+INFO_JSON="$DIR/$NS_NAME/info.json"
 cat > $INFO_JSON <<Endofmessage
 {
   "$NS_NAME": {

--- a/test/node-insert.js
+++ b/test/node-insert.js
@@ -130,7 +130,7 @@ describe('node-insert', function() {
                 if (inserted) {
                     tutils.delete_node(node_id, auth, function(err) {
                         if (err) {
-                            console.err('Problem deleting inserted node: ', err);
+                            console.error('Problem deleting inserted node: ', err);
                         }
                     });
                 }
@@ -327,7 +327,7 @@ describe('node-insert', function() {
                     // invalid, but if we DID insert anyway (perhaps due to a bug),
                     // then we clean up after ourselves by deleting.
                     tutils.delete_node(node_id, auth, function(err) {
-                        console.err('Problem deleting inserted node: ', err);
+                        console.error('Problem deleting inserted node: ', err);
                     });
                 }
 


### PR DESCRIPTION
Minor fixes in OSDF repo.
use `#!/usr/bin/env node`
use `console.error`
fix `bin/new_namespaces` script